### PR TITLE
Download / install instructions web page

### DIFF
--- a/web/release-page.html
+++ b/web/release-page.html
@@ -9,11 +9,13 @@ This is probcomp-stack-0.1, released by the
 on 19 July 2017.  Blah blah one
 sentence description of what this is blah blah 
 <a href="https://jupyter.org/">jupyter notebooks</a> blah blah.
+</p>
 
 <blockquote>
 <p>
 [VERSION NUMBER NOTE - the version number will change to 0.2 before 7/19, but as
 of this writing there is only a version 0.1.]
+</p>
 </blockquote>
 
 <h2>
@@ -23,27 +25,32 @@ Before you start
 <p>
 This is research software.  It is certain to contain flaws.  No warranty of any kind
 is implied by this release.  Use it at your own risk.
+</p>
 
 <p>
 The installation requires some level of technical ability,
 specifically the ability to use the command line, and to install
 prerequisite software if required.
+</p>
 
 <h3>Hardware requirements</h3>
 
+<p>
 The notebooks in this release have successfully executed with the
 following hardware configuration, with acceptable performance:
+</p>
 
 <ul>
-  <li> 60G RAM
-  <li> 32 CPU cores
-  <li> 2.5 Gbyte available disk space
+  <li> 60G RAM </li>
+  <li> 32 CPU cores </li>
+  <li> 2.5 Gbyte available disk space </li>
 </ul>
 
 <p>
 Running with much less than this may lead to heavy load, long
 delays, and/or crashes. Actual application demands vary depending on the
 particulars of the data set, both on its size and on the data itself.
+</p>
 
 <p>
 We assume that you are using a workstation possessing the recommended
@@ -51,6 +58,7 @@ resources via the workstation's monitor and keyboard.  Client/server
 configurations are possible for this software with additional
 setup, but methods vary by operating system.  We have not prepared
 documentation for client/server configurations.
+</p>
 
 <!-- 
 <blockquote>
@@ -84,6 +92,7 @@ anticipate that it will run on any operating system that supports
 variants, Mac OS X, and 
 <a href="https://docs.docker.com/docker-for-windows/install/#what-to-know-before-you-install"
 >64-bit Windows 10</a>.
+</p>
 
 <p>
 probcomp-stack-0.1 requires Docker version 1.6 or later.
@@ -93,6 +102,7 @@ probcomp-stack-0.1 requires Docker version 1.6 or later.
 You will need an unzip program such as unzip or WinZip.  One of these
 is part of most operating system distributions, so it is unlikely that you will
 need to install it.
+</p>
 
 <h2>Download and installation</h2>
 
@@ -112,8 +122,10 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
   </li>
 
   <li>
+    <p>
       At the command line, navigate to the directory containing
       <code>probcomp-stack-full-0.1.tar</code>.
+    </p>
   <li>
     <p>
       Tell docker about the probcomp-stack container as follows:</p>
@@ -128,6 +140,7 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
   and skip the unzip step.  Docker can take in .tgz files directly so
   this requires no explanation or prerequisiste.
   Remove discussion of unzip from the documentation.]
+</p>
 </blockquote>
 
 <h2>How to run</h2>
@@ -136,6 +149,7 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
   <li>
       At the command line, navigate to the directory containing
       <code>probcomp-stack-full-0.1.tar</code>.
+  </li>
   <li>
     <p>
       Start the Docker container as follows:</p>
@@ -144,15 +158,18 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
      probcomp/stack-release:0.1</code></pre>
   </li>
   <li>
-    <p>In a web browser, visit the location <a href="http://localhost:8080/"><code>http://localhost:8080/</code></a></p>
+    <p>In a web browser, visit the location 
+    <a href="http://localhost:8080/"><code>http://localhost:8080/</code></a></p>
   </li>
 </ol>
 
 <p>
 In the unlikely event that port 8080 is unavailable on your machine, feel free to choose a
 different port.
+</p>
 
 <h3>Saving your work</h3>
 
-To save any changed or new notebooks, use either 'Save and checkpoint'
-or 'Download' in the Jupyter notebook 'File' menu.
+<p>
+To save any changed or new notebooks, use 'Download' in the Jupyter notebook 'File' menu.
+</p>

--- a/web/release-page.html
+++ b/web/release-page.html
@@ -1,0 +1,119 @@
+<h1>
+probcomp-stack-0.2
+</h1>
+
+This is probcomp-stack-0.2, released on 19 July 2017.  Blah blah one
+sentence description of what this is blah blah <a href="https://jupyter.org/">jupyter notebooks</a> blah blah.
+
+<p>
+[QUESTION: what is this thing to be called, exactly, and what is its
+version number?  The 'alpha' documented 
+<a href="https://probcomp-1.csail.mit.edu/stack/">here</a> is
+called variously 'probcomp stack' or 'stack 0.1'.]
+
+<h2>
+Before you start
+</h2>
+
+<p>
+This is research software.  It is certain to contain bugs.  No warranty of any kind
+is implied by this release.  Use it at your own risk.
+
+<p>
+The installation requires some level of technical ability,
+specifically the ability to use the command line, and to install
+prerequisite software if required.
+
+<h3>Hardware requirements</h3>
+
+The notebooks in this release have successfully executed with the
+following hardware configuration, with acceptable performance:
+
+<ul>
+  <li> 60G RAM
+  <li> 32 CPU cores
+</ul>
+
+<p>
+Running with much less than this may lead to heavy load, long
+delays, and/or crashes. Actual application demands vary depending on the
+particulars of the data set, both its size and the data itself.
+
+<p>
+We assume that you are using a workstation possessing the recommended
+resources via the workstation's monitor and keyboard.
+Client/server configurations are possible for this software, 
+and some of you will be able to figure out how to configure it in this way.
+This subject beyond the scope of the present document.
+
+
+<h3>Software prerequisistes</h3>
+
+<p>
+probcomp-stack-0.2 has been tested on ubuntu 16.04.2 LTS, but we
+anticipate that it will run on any operating system that supports
+<a href="https://www.docker.com/">Docker</a>, such as most GNU/Linux variants and Mac OS X.
+
+<p>
+probcomp-stack-0.2 requires <a href="https://www.docker.com/">Docker</a> version 6 or later.
+</p>
+
+<p>
+You will need an unzip program, specifically unzip, winzip, or
+similar; one of these is built in to most operating systems,
+and may automatically launch on download.
+
+<h2>Download and installation</h2>
+
+<ol>
+  <li>
+    <p>Download <a href="probcomp-stack-full-0.2.zip">the stack 0.2 distribution</a> (370 MB).</p>
+
+    <p>Optional: To check the integrity of the download, the SHA256
+checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p>
+  </li>
+
+  <li>
+    <p>If the file has not been unzipped automatically on download, unzip it using WinZip or similar.
+    The result will be a single file, probcomp-stack-full-0.2.tar,
+    and may be placed wherever you like.</p>
+  </li>
+</ol>
+
+<h2>How to run</h2>
+
+<ol>
+  <li>
+    <p>
+      At the command line, navigate to the directory containing
+      probcomp-stack-full-0.2.tar.
+      Start the Docker container as follows:</p>
+
+    <pre><code> $ docker load --input probcomp-stack-full-0.2.tar
+ $ docker run --rm --publish 127.0.0.1:8080:8080/tcp \
+     probcomp/stack-release:0.1</code></pre>
+  </li>
+  <li>
+    <p>In a web browser, visit the location <a href="http://localhost:8080/">http://localhost:8080/</a></p>
+  </li>
+</ol>
+
+<p>
+[QUESTION: Is the <code>docker load</code> step really part of
+installation, in that it only has to run once at install time?  I
+don't understand how this works.  But if this is so,
+the <code>load</code> step should be documented as part of
+installation, not under 'how to run'.]
+
+<p>
+[QUESTION: Is the application self-explanatory from that point that
+the home web page comes up?  Need to check.]
+
+<p>
+In the unlikely even port 8080 is unavailable on your machine, feel free to choose a
+different port.
+
+<h3>Saving your work</h3>
+
+To save any changed or new notebooks, use either 'Save and checkpoint'
+or 'Download' in the Jupyter notebook 'File' menu.

--- a/web/release-page.html
+++ b/web/release-page.html
@@ -35,6 +35,7 @@ following hardware configuration, with acceptable performance:
 <ul>
   <li> 60G RAM
   <li> 32 CPU cores
+  <li> 1.4 Gbyte [?] available disk space
 </ul>
 
 <p>
@@ -92,7 +93,8 @@ need to install it.
 
 <ol>
   <li>
-    <p>Download <a href="probcomp-stack-full-0.1.zip">the probcomp-stack-0.1 distribution</a> (370 MB).</p>
+    <p>Download <a href="https://probcomp-1.csail.mit.edu/probcomp-stack/probcomp-stack-full-0.1.zip"
+       >the probcomp-stack-0.1 distribution</a> (370 MB).</p>
 
     <p>Optional: To check the integrity of the download, the SHA256
 checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p>
@@ -101,7 +103,7 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
   <li>
     <p>If the file has not been unzipped automatically on download, unzip it using WinZip or unzip.
     The result will be a single file, <code>probcomp-stack-full-0.1.tar</code>,
-    and may be placed wherever you like.</p>
+    and may be placed wherever you like.  The .zip file can then be deleted.</p>
   </li>
 </ol>
 

--- a/web/release-page.html
+++ b/web/release-page.html
@@ -1,22 +1,25 @@
 <h1>
-probcomp-stack-0.2
+probcomp-stack-0.1
 </h1>
 
-This is probcomp-stack-0.2, released on 19 July 2017.  Blah blah one
-sentence description of what this is blah blah <a href="https://jupyter.org/">jupyter notebooks</a> blah blah.
+<p>
+[VERSION NUMBER - everything will change to 0.2, but as
+of this writing only version 0.1 is present.]
 
 <p>
-[QUESTION: what is this thing to be called, exactly, and what is its
-version number?  The 'alpha' documented 
-<a href="https://probcomp-1.csail.mit.edu/stack/">here</a> is
-called variously 'probcomp stack' or 'stack 0.1'.]
+This is probcomp-stack-0.1, released by the 
+<a href="http://probcomp.csail.mit.edu/"
+>MIT Probabilistic Computing Project</a>
+on 19 July 2017.  Blah blah one
+sentence description of what this is blah blah 
+<a href="https://jupyter.org/">jupyter notebooks</a> blah blah.
 
 <h2>
 Before you start
 </h2>
 
 <p>
-This is research software.  It is certain to contain bugs.  No warranty of any kind
+This is research software.  It is certain to contain flaws.  No warranty of any kind
 is implied by this release.  Use it at your own risk.
 
 <p>
@@ -37,81 +40,109 @@ following hardware configuration, with acceptable performance:
 <p>
 Running with much less than this may lead to heavy load, long
 delays, and/or crashes. Actual application demands vary depending on the
-particulars of the data set, both its size and the data itself.
+particulars of the data set, both on its size and on the data itself.
 
 <p>
 We assume that you are using a workstation possessing the recommended
-resources via the workstation's monitor and keyboard.
-Client/server configurations are possible for this software, 
-and some of you will be able to figure out how to configure it in this way.
-This subject beyond the scope of the present document.
+resources via the workstation's monitor and keyboard.  Client/server
+configurations may be possible for this software with additional
+setup, but methods vary by operating system.  We have not prepared
+documentation for client/server configurations.
+
+<p>
+[NOTE: It is JAR's feeling that very few people will have a hefty
+workstation with a head; indeed I have personally never seen such a thing.  They are
+much more likely to have a hefty server and an ordinary laptop or desktop.  This
+is why I feel compelled to say <i>something</i> about client/server
+configuration: If we do not acknowledge the possibility, then it will sound
+as if a same-computer configuration is <i>required</i> when it is not,
+and we will immediately decimate the potential user base.]
+
+<p>
+[CONTINUED: Mentioning 'ssh tunnel' could be a useful hint
+for some portion of the audience (not all of it), but I understand
+that we're not supposed to mention ssh for some reason?  There are
+other access options (e.g. https) but we don't have time before Wednesday to
+implement any hooks or features that would make this setup easy and
+documentable.  I see the two constraints "no new implementation work now" and
+"do not mention ssh" as forcing the above weasel-wording.]
+
 
 
 <h3>Software prerequisistes</h3>
 
 <p>
-probcomp-stack-0.2 has been tested on ubuntu 16.04.2 LTS, but we
+probcomp-stack-0.1 has been tested on ubuntu 16.04.2 LTS, but we
 anticipate that it will run on any operating system that supports
-<a href="https://www.docker.com/">Docker</a>, such as most GNU/Linux variants and Mac OS X.
+<a href="https://www.docker.com/">Docker</a>, such as most GNU/Linux
+variants, Mac OS X, and 
+<a href="https://docs.docker.com/docker-for-windows/install/#what-to-know-before-you-install"
+>64-bit Windows 10</a>.
 
 <p>
-probcomp-stack-0.2 requires <a href="https://www.docker.com/">Docker</a> version 6 or later.
+probcomp-stack-0.1 requires Docker version 1.6 or later.
 </p>
 
 <p>
-You will need an unzip program, specifically unzip, winzip, or
-similar; one of these is built in to most operating systems,
-and may automatically launch on download.
+You will need an unzip program such as unzip or WinZip.  One of these
+is part of most operating system distributions, so it is unlikely that you will
+need to install it.
 
 <h2>Download and installation</h2>
 
 <ol>
   <li>
-    <p>Download <a href="probcomp-stack-full-0.2.zip">the stack 0.2 distribution</a> (370 MB).</p>
+    <p>Download <a href="probcomp-stack-full-0.1.zip">the probcomp-stack-0.1 distribution</a> (370 MB).</p>
 
     <p>Optional: To check the integrity of the download, the SHA256
 checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p>
   </li>
 
   <li>
-    <p>If the file has not been unzipped automatically on download, unzip it using WinZip or similar.
-    The result will be a single file, probcomp-stack-full-0.2.tar,
+    <p>If the file has not been unzipped automatically on download, unzip it using WinZip or unzip.
+    The result will be a single file, <code>probcomp-stack-full-0.1.tar</code>,
     and may be placed wherever you like.</p>
   </li>
 </ol>
+
+<p>[QUESTION: Why do the filenames include the word <code>full</code>?
+  Can that be removed, for the sake of consistency?... not too important.]
 
 <h2>How to run</h2>
 
 <ol>
   <li>
-    <p>
       At the command line, navigate to the directory containing
-      probcomp-stack-full-0.2.tar.
+      <code>probcomp-stack-full-0.1.tar</code>.
+  <li>
+    <p>
       Start the Docker container as follows:</p>
 
-    <pre><code> $ docker load --input probcomp-stack-full-0.2.tar
+    <pre><code> $ docker load --input probcomp-stack-full-0.1.tar
  $ docker run --rm --publish 127.0.0.1:8080:8080/tcp \
      probcomp/stack-release:0.1</code></pre>
   </li>
   <li>
-    <p>In a web browser, visit the location <a href="http://localhost:8080/">http://localhost:8080/</a></p>
+    <p>In a web browser, visit the location <a href="http://localhost:8080/"><code>http://localhost:8080/</code></a></p>
   </li>
 </ol>
 
 <p>
-[QUESTION: Is the <code>docker load</code> step really part of
-installation, in that it only has to run once at install time?  I
-don't understand how this works.  But if this is so,
+In the unlikely event that port 8080 is unavailable on your machine, feel free to choose a
+different port.
+
+<p>
+[QUESTION: Is the <code>docker load</code> step actually part of
+installation, i.e. does it only have to run once at install time?  I
+don't understand how this works (daemon, state, etc.).  But if <code>load</code>
+need only be done once, the
 the <code>load</code> step should be documented as part of
 installation, not under 'how to run'.]
 
 <p>
 [QUESTION: Is the application self-explanatory from that point that
-the home web page comes up?  Need to check.]
-
-<p>
-In the unlikely even port 8080 is unavailable on your machine, feel free to choose a
-different port.
+the home web page comes up?  Need to check.  If not, say here what
+people should do once they connect to it.]
 
 <h3>Saving your work</h3>
 

--- a/web/release-page.html
+++ b/web/release-page.html
@@ -1,22 +1,49 @@
 <h1>
-probcomp-stack-0.1
+probcomp-stack-0.2
 </h1>
 
 <p>
-This is probcomp-stack-0.1, released by the 
+This is the release page for probcomp-stack-0.2 from the 
 <a href="http://probcomp.csail.mit.edu/"
->MIT Probabilistic Computing Project</a>
-on 19 July 2017.  Blah blah one
-sentence description of what this is blah blah 
-<a href="https://jupyter.org/">jupyter notebooks</a> blah blah.
+>MIT Probabilistic Computing Project</a>.
+
+The release is a stand-alone 
+<a href="https://www.docker.com/">docker</a> image that includes a
+running
+<a href="https://jupyter.org/">jupyter notebook server</a> through which the
+probcomp software and documentation can be accessed.
 </p>
 
-<blockquote>
 <p>
-[VERSION NUMBER NOTE - the version number will change to 0.2 before 7/19, but as
-of this writing there is only a version 0.1.]
+The probcomp stack contains three probabilistic programming platforms:
 </p>
-</blockquote>
+
+<ol>
+<li> The <a href="http://probcomp.csail.mit.edu/bayesdb/doc/index.html">bayeslite</a>
+  implementation of BayesDB, a platform for
+  AI-assisted data science. 
+  (<a href="https://github.com/probcomp/bayeslite">github</a>)
+</li>
+
+<li> The <a href="http://probcomp.csail.mit.edu/venture/">venturelite</a> implementation of 
+  Venture, an interactive
+  probabilistic reasoning platform that has been used for teaching
+  probabilistic modeling and inference and for rapid prototyping in
+  computer vision, data science, and robotics. </li>
+
+<li> A pre-alpha version of Gen.jl, a Julia implementation of Gen, a
+  probabilistic meta-programming platform and high-performance run-time
+  system suitable for production engineering in probabilistic
+  robotics. (no documentation is available at this time)</li>
+</ol>
+
+<p>
+Key capabilities of these platforms can be accessed via the notebooks included with this release.
+</p>
+
+<p>
+Version 0.2 of the probcomp stack was created on 18 July 2017.
+</p>
 
 <h2>
 Before you start
@@ -86,7 +113,7 @@ documentable.  I see the two constraints "no new implementation work now" and
 <h3>Software prerequisites</h3>
 
 <p>
-probcomp-stack-0.1 has been tested on ubuntu 16.04.2 LTS, but we
+probcomp-stack-0.2 has been tested on ubuntu 16.04.2 LTS, but we
 anticipate that it will run on any operating system that supports
 <a href="https://www.docker.com/">Docker</a>, such as most GNU/Linux
 variants, Mac OS X, and 
@@ -95,67 +122,47 @@ variants, Mac OS X, and
 </p>
 
 <p>
-probcomp-stack-0.1 requires Docker version 1.6 or later.
-</p>
-
-<p>
-You will need an unzip program such as unzip or WinZip.  One of these
-is part of most operating system distributions, so it is unlikely that you will
-need to install it.
+probcomp-stack-0.2 requires Docker version 1.6 or later.
 </p>
 
 <h2>Download and installation</h2>
 
 <ol>
   <li>
-    <p>Download and save <a href="https://probcomp-1.csail.mit.edu/probcomp-stack/probcomp-stack-full-0.1.zip"
-       >the probcomp-stack-0.1 distribution</a> (370 MB).</p>
+    <p>Download and save <a href="https://probcomp-1.csail.mit.edu/probcomp-stack/probcomp-stack-full-0.2.tar.gz"
+       >the probcomp-stack-0.2 distribution</a> (370 MB).</p>
 
     <p>Optional: To check the integrity of the download, verify that the SHA256
-checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p>
-  </li>
-
-  <li>
-    <p>If the file was not unzipped automatically on download, unzip it using WinZip or unzip.
-    The result will be a single file, <code>probcomp-stack-full-0.1.tar</code>,
-    and may be placed wherever you like.  The .zip file can then be deleted.</p>
+checksum is 145afeb0ee0cfadbe874e301c4117294ab7055c737eeab0f18135f35aedf2f98.</p>
   </li>
 
   <li>
     <p>
       At the command line, navigate to the directory containing
-      <code>probcomp-stack-full-0.1.tar</code>.
+      <code>probcomp-stack-full-0.2.tar.gz</code>.
     </p>
   <li>
     <p>
       Tell docker about the probcomp-stack container as follows:</p>
 
-    <pre><code> $ docker load --input probcomp-stack-full-0.1.tar</code></pre>
+    <pre><code> $ docker load --input probcomp-stack-full-0.2.tar.gz</code></pre>
   </li>
 
 </ol>
-
-<blockquote>
-<p>[IDEA: Have the user download a .tgz file instead of a .zip file,
-  and skip the unzip step.  Docker can take in .tgz files directly so
-  this requires no explanation or prerequisiste.
-  Remove discussion of unzip from the documentation.]
-</p>
-</blockquote>
 
 <h2>How to run</h2>
 
 <ol>
   <li>
       At the command line, navigate to the directory containing
-      <code>probcomp-stack-full-0.1.tar</code>.
+      <code>probcomp-stack-full-0.2.tar</code>.
   </li>
   <li>
     <p>
       Start the Docker container as follows:</p>
 
     <pre><code> $ docker run --rm --publish 127.0.0.1:8080:8080/tcp \
-     probcomp/stack-release:0.1</code></pre>
+     probcomp/stack-release:0.2</code></pre>
   </li>
   <li>
     <p>In a web browser, visit the location 

--- a/web/release-page.html
+++ b/web/release-page.html
@@ -3,16 +3,18 @@ probcomp-stack-0.1
 </h1>
 
 <p>
-[VERSION NUMBER - everything will change to 0.2, but as
-of this writing only version 0.1 is present.]
-
-<p>
 This is probcomp-stack-0.1, released by the 
 <a href="http://probcomp.csail.mit.edu/"
 >MIT Probabilistic Computing Project</a>
 on 19 July 2017.  Blah blah one
 sentence description of what this is blah blah 
 <a href="https://jupyter.org/">jupyter notebooks</a> blah blah.
+
+<blockquote>
+<p>
+[VERSION NUMBER NOTE - the version number will change to 0.2 before 7/19, but as
+of this writing there is only a version 0.1.]
+</blockquote>
 
 <h2>
 Before you start
@@ -35,7 +37,7 @@ following hardware configuration, with acceptable performance:
 <ul>
   <li> 60G RAM
   <li> 32 CPU cores
-  <li> 1.4 Gbyte [?] available disk space
+  <li> 2.5 Gbyte available disk space
 </ul>
 
 <p>
@@ -46,10 +48,12 @@ particulars of the data set, both on its size and on the data itself.
 <p>
 We assume that you are using a workstation possessing the recommended
 resources via the workstation's monitor and keyboard.  Client/server
-configurations may be possible for this software with additional
+configurations are possible for this software with additional
 setup, but methods vary by operating system.  We have not prepared
 documentation for client/server configurations.
 
+<!-- 
+<blockquote>
 <p>
 [NOTE: It is JAR's feeling that very few people will have a hefty
 workstation with a head; indeed I have personally never seen such a thing.  They are
@@ -67,10 +71,11 @@ other access options (e.g. https) but we don't have time before Wednesday to
 implement any hooks or features that would make this setup easy and
 documentable.  I see the two constraints "no new implementation work now" and
 "do not mention ssh" as forcing the above weasel-wording.]
+</blockquote>
+ -->
 
 
-
-<h3>Software prerequisistes</h3>
+<h3>Software prerequisites</h3>
 
 <p>
 probcomp-stack-0.1 has been tested on ubuntu 16.04.2 LTS, but we
@@ -93,22 +98,37 @@ need to install it.
 
 <ol>
   <li>
-    <p>Download <a href="https://probcomp-1.csail.mit.edu/probcomp-stack/probcomp-stack-full-0.1.zip"
+    <p>Download and save <a href="https://probcomp-1.csail.mit.edu/probcomp-stack/probcomp-stack-full-0.1.zip"
        >the probcomp-stack-0.1 distribution</a> (370 MB).</p>
 
-    <p>Optional: To check the integrity of the download, the SHA256
+    <p>Optional: To check the integrity of the download, verify that the SHA256
 checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p>
   </li>
 
   <li>
-    <p>If the file has not been unzipped automatically on download, unzip it using WinZip or unzip.
+    <p>If the file was not unzipped automatically on download, unzip it using WinZip or unzip.
     The result will be a single file, <code>probcomp-stack-full-0.1.tar</code>,
     and may be placed wherever you like.  The .zip file can then be deleted.</p>
   </li>
+
+  <li>
+      At the command line, navigate to the directory containing
+      <code>probcomp-stack-full-0.1.tar</code>.
+  <li>
+    <p>
+      Tell docker about the probcomp-stack container as follows:</p>
+
+    <pre><code> $ docker load --input probcomp-stack-full-0.1.tar</code></pre>
+  </li>
+
 </ol>
 
-<p>[QUESTION: Why do the filenames include the word <code>full</code>?
-  Can that be removed, for the sake of consistency?... not too important.]
+<blockquote>
+<p>[IDEA: Have the user download a .tgz file instead of a .zip file,
+  and skip the unzip step.  Docker can take in .tgz files directly so
+  this requires no explanation or prerequisiste.
+  Remove discussion of unzip from the documentation.]
+</blockquote>
 
 <h2>How to run</h2>
 
@@ -120,8 +140,7 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
     <p>
       Start the Docker container as follows:</p>
 
-    <pre><code> $ docker load --input probcomp-stack-full-0.1.tar
- $ docker run --rm --publish 127.0.0.1:8080:8080/tcp \
+    <pre><code> $ docker run --rm --publish 127.0.0.1:8080:8080/tcp \
      probcomp/stack-release:0.1</code></pre>
   </li>
   <li>
@@ -132,19 +151,6 @@ checksum is 79183671ab39c8625c49fab668069013e763b790054707febd95bc90eaa31391.</p
 <p>
 In the unlikely event that port 8080 is unavailable on your machine, feel free to choose a
 different port.
-
-<p>
-[QUESTION: Is the <code>docker load</code> step actually part of
-installation, i.e. does it only have to run once at install time?  I
-don't understand how this works (daemon, state, etc.).  But if <code>load</code>
-need only be done once, the
-the <code>load</code> step should be documented as part of
-installation, not under 'how to run'.]
-
-<p>
-[QUESTION: Is the application self-explanatory from that point that
-the home web page comes up?  Need to check.  If not, say here what
-people should do once they connect to it.]
 
 <h3>Saving your work</h3>
 


### PR DESCRIPTION
Addresses #36.

I'm not saying this PR is ready for merge; my purpose here is to signal that it is wanting review.

Commit 014f73a is on the web [here](https://probcomp-1.csail.mit.edu/probcomp-stack/).

Remaining tasks before deployment
 - [ ] Decide whether the download is a .tar.zip file or a .tgz file (this is for @vkmvkmvkmvkm )
 - [ ] If .tgz then update the documentation
 - [ ] Trim the set of notebooks included and bump the version number to 0.2 (@riastradh in progress)
 - [ ] Automate the application of the css and boilerplate, perhaps using 'bundle' like the main web site?? I don't yet understand how this would be done given that it's not the main web site.
